### PR TITLE
add SpdxLicenses::getResourcesDir method

### DIFF
--- a/bin/update-spdx-licenses
+++ b/bin/update-spdx-licenses
@@ -4,8 +4,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Composer\Spdx\SpdxLicensesUpdater;
-use Composer\Spdx\SpdxLicenses;
 
 $updater = new SpdxLicensesUpdater;
-$updater->dumpLicenses(SpdxLicenses::getResourcesDir() . 'spdx-licenses.json');
-$updater->dumpExceptions(SpdxLicenses::getResourcesDir() . 'spdx-exceptions.json');
+$updater->dumpLicenses();
+$updater->dumpExceptions();

--- a/bin/update-spdx-licenses
+++ b/bin/update-spdx-licenses
@@ -4,7 +4,8 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Composer\Spdx\SpdxLicensesUpdater;
+use Composer\Spdx\SpdxLicenses;
 
 $updater = new SpdxLicensesUpdater;
-$updater->dumpLicenses(__DIR__ . '/../res/spdx-licenses.json');
-$updater->dumpExceptions(__DIR__ . '/../res/spdx-exceptions.json');
+$updater->dumpLicenses(SpdxLicenses::getResourcesDir() . 'spdx-licenses.json');
+$updater->dumpExceptions(SpdxLicenses::getResourcesDir() . 'spdx-exceptions.json');

--- a/src/SpdxLicenses.php
+++ b/src/SpdxLicenses.php
@@ -167,10 +167,18 @@ class SpdxLicenses
         return $this->isValidLicenseString($license);
     }
 
+    /**
+     * @return string
+     */
+    public static function getResourcesDir()
+    {
+        return dirname(__DIR__) . '/res/';
+    }
+
     private function loadLicenses()
     {
         if (null === $this->licenses) {
-            $jsonFile = file_get_contents(__DIR__ . '/../res/spdx-licenses.json');
+            $jsonFile = file_get_contents(self::getResourcesDir() . 'spdx-licenses.json');
             $this->licenses = json_decode($jsonFile, true);
         }
     }
@@ -178,7 +186,7 @@ class SpdxLicenses
     private function loadExceptions()
     {
         if (null === $this->exceptions) {
-            $jsonFile = file_get_contents(__DIR__ . '/../res/spdx-exceptions.json');
+            $jsonFile = file_get_contents(self::getResourcesDir() . 'spdx-exceptions.json');
             $this->exceptions = json_decode($jsonFile, true);
         }
     }

--- a/src/SpdxLicenses.php
+++ b/src/SpdxLicenses.php
@@ -13,6 +13,8 @@ namespace Composer\Spdx;
 
 class SpdxLicenses
 {
+    const LICENSES_FILE = 'spdx-licenses.json';
+    const EXCEPTIONS_FILE = 'spdx-exceptions.json';
     /**
      * Contains all the licenses.
      *
@@ -172,13 +174,13 @@ class SpdxLicenses
      */
     public static function getResourcesDir()
     {
-        return dirname(__DIR__) . '/res/';
+        return dirname(__DIR__) . '/res';
     }
 
     private function loadLicenses()
     {
         if (null === $this->licenses) {
-            $jsonFile = file_get_contents(self::getResourcesDir() . 'spdx-licenses.json');
+            $jsonFile = file_get_contents(self::getResourcesDir() . '/' . self::LICENSES_FILE);
             $this->licenses = json_decode($jsonFile, true);
         }
     }
@@ -186,7 +188,7 @@ class SpdxLicenses
     private function loadExceptions()
     {
         if (null === $this->exceptions) {
-            $jsonFile = file_get_contents(self::getResourcesDir() . 'spdx-exceptions.json');
+            $jsonFile = file_get_contents(self::getResourcesDir() . '/' . self::EXCEPTIONS_FILE);
             $this->exceptions = json_decode($jsonFile, true);
         }
     }

--- a/src/SpdxLicensesUpdater.php
+++ b/src/SpdxLicensesUpdater.php
@@ -23,8 +23,11 @@ class SpdxLicensesUpdater
      * @param string $file
      * @param string $url
      */
-    public function dumpLicenses($file, $url = 'https://spdx.org/licenses/index.html')
+    public function dumpLicenses($file = '', $url = 'https://spdx.org/licenses/index.html')
     {
+        if (empty($file)) {
+            $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE;
+        }
         $options = 0;
 
         if (defined('JSON_PRETTY_PRINT')) {
@@ -43,8 +46,11 @@ class SpdxLicensesUpdater
      * @param string $file
      * @param string $url
      */
-    public function dumpExceptions($file, $url = 'https://spdx.org/licenses/exceptions-index.html')
+    public function dumpExceptions($file = '', $url = 'https://spdx.org/licenses/exceptions-index.html')
     {
+        if (empty($file)) {
+            $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::EXCEPTIONS_FILE;
+        }
         $options = 0;
 
         if (defined('JSON_PRETTY_PRINT')) {

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -53,6 +53,14 @@ class SpdxLicensesTest extends \PHPUnit_Framework_TestCase
         $this->license->validate($invalidArgument);
     }
 
+    public function testGetResourcesDir()
+    {
+        $dir = SpdxLicenses::getResourcesDir();
+        $this->assertTrue(is_dir($dir));
+        $this->assertTrue(is_file($dir . 'spdx-licenses.json'));
+        $this->assertTrue(is_file($dir . 'spdx-exceptions.json'));
+    }
+
     public function testGetLicenseByIdentifier()
     {
         $license = $this->license->getLicenseByIdentifier('AGPL-1.0');

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -83,7 +83,7 @@ class SpdxLicensesTest extends \PHPUnit_Framework_TestCase
      */
     public static function provideValidLicenses()
     {
-        $json = file_get_contents(__DIR__ . '/../res/spdx-licenses.json');
+        $json = file_get_contents(SpdxLicenses::getResourcesDir() . '/spdx-licenses.json');
         $licenses = json_decode($json, true);
         $identifiers = array_keys($licenses);
 

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -57,8 +57,8 @@ class SpdxLicensesTest extends \PHPUnit_Framework_TestCase
     {
         $dir = SpdxLicenses::getResourcesDir();
         $this->assertTrue(is_dir($dir));
-        $this->assertTrue(is_file($dir . 'spdx-licenses.json'));
-        $this->assertTrue(is_file($dir . 'spdx-exceptions.json'));
+        $this->assertTrue(is_file($dir . '/' . SpdxLicenses::LICENSES_FILE), $dir . SpdxLicenses::LICENSES_FILE. ' not a file');
+        $this->assertTrue(is_file($dir . '/' . SpdxLicenses::EXCEPTIONS_FILE), $dir . SpdxLicenses::EXCEPTIONS_FILE . ' not a file');
     }
 
     public function testGetLicenseByIdentifier()
@@ -91,7 +91,7 @@ class SpdxLicensesTest extends \PHPUnit_Framework_TestCase
      */
     public static function provideValidLicenses()
     {
-        $json = file_get_contents(SpdxLicenses::getResourcesDir() . '/spdx-licenses.json');
+        $json = file_get_contents(SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE);
         $licenses = json_decode($json, true);
         $identifiers = array_keys($licenses);
 


### PR DESCRIPTION
This method make resources path defined in a single place.

This make "downstream" distribution easier (as "res" static files  are  outside the library tree).
Shouldn't change anything for other usage.