### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -11,7 +11,9 @@
 
 namespace Composer\Spdx;
 
-class SpdxLicensesTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SpdxLicensesTest extends TestCase
 {
     /**
      * @var SpdxLicenses
@@ -143,7 +145,7 @@ class SpdxLicensesTest extends \PHPUnit_Framework_TestCase
     {
         $licenseNull = $this->licenses->getExceptionByIdentifier('Font-exception-2.0-Errorl');
         $this->assertNull($licenseNull);
-        
+
         $license = $this->licenses->getExceptionByIdentifier('Font-exception-2.0');
         $this->assertInternalType('array', $license);
         $this->assertSame('Font exception 2.0', $license[0]);

--- a/tests/SpdxLicensesUpdaterTest.php
+++ b/tests/SpdxLicensesUpdaterTest.php
@@ -11,7 +11,9 @@
 
 namespace Composer\Spdx;
 
-class SpdxLicensesUpdaterTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SpdxLicensesUpdaterTest extends TestCase
 {
     /**
      * @var SpdxLicenses


### PR DESCRIPTION
Simple version of [composer/spdx-licenses#11](https://github.com/composer/spdx-licenses/pull/11).

Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).