### PR TITLE
Use assertFileExists

### DIFF
--- a/tests/SpdxLicensesUpdaterTest.php
+++ b/tests/SpdxLicensesUpdaterTest.php
@@ -38,18 +38,18 @@ class SpdxLicensesUpdaterTest extends TestCase
     public function testDumpLicenses()
     {
         $this->updater->dumpLicenses();
-        $this->assertTrue(file_exists(SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE));
+        $this->assertFileExists(SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE);
 
         $this->updater->dumpLicenses($this->licenseFile);
-        $this->assertTrue(file_exists($this->licenseFile));
+        $this->assertFileExists($this->licenseFile);
     }
 
     public function testDumpExceptions()
     {
         $this->updater->dumpExceptions();
-        $this->assertTrue(file_exists(SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::EXCEPTIONS_FILE));
+        $this->assertFileExists(SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::EXCEPTIONS_FILE);
 
         $this->updater->dumpExceptions($this->exceptionFile);
-        $this->assertTrue(file_exists($this->exceptionFile));
+        $this->assertFileExists($this->exceptionFile);
     }
 }


### PR DESCRIPTION
I've refactored some tests using [`assertFileExists`](https://phpunit.de/manual/5.7/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileExists).