### PR TITLE
Update to SPDX 3.0 license list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $licenses->isOsiApprovedByIdentifier('MIT');
 $licenses->validate($input);
 ```
 
-> Read the [specifications](https://spdx.org/SPDX-specifications/spdx-version-2.0)
+> Read the [specifications](https://spdx.org/specifications)
 > to find out more about valid license expressions.
 
 Requirements
@@ -59,7 +59,8 @@ composer/spdx-licenses is licensed under the MIT License, see the LICENSE file f
 Source
 ------
 
-License information taken from [spdx.org](https://spdx.org/).
+License information is curated by [SPDX](https://spdx.org/). The data is pulled from the
+[License List Data](https://github.com/spdx/license-list-data) repository.
 
 * [Licenses](https://spdx.org/licenses/index.html)
 * [License Exceptions](https://spdx.org/licenses/exceptions-index.html)

--- a/res/spdx-exceptions.json
+++ b/res/spdx-exceptions.json
@@ -1,6 +1,6 @@
 {
     "389-exception": [
-        "389 Directory Server\nException"
+        "389 Directory Server Exception"
     ],
     "Autoconf-exception-2.0": [
         "Autoconf exception 2.0"
@@ -10,6 +10,9 @@
     ],
     "Bison-exception-2.2": [
         "Bison exception 2.2"
+    ],
+    "Bootloader-exception": [
+        "Bootloader Distribution Exception"
     ],
     "Classpath-exception-2.0": [
         "Classpath exception 2.0"
@@ -49,6 +52,9 @@
     ],
     "Libtool-exception": [
         "Libtool Exception"
+    ],
+    "Linux-syscall-note": [
+        "Linux Syscall Note"
     ],
     "LZMA-exception": [
         "LZMA exception"

--- a/res/spdx-licenses.json
+++ b/res/spdx-licenses.json
@@ -1,7 +1,7 @@
 {
     "0BSD": [
         "BSD Zero Clause License",
-        true
+        false
     ],
     "AAL": [
         "Attribution Assurance License",
@@ -51,8 +51,12 @@
         "Affero General Public License v1.0",
         false
     ],
-    "AGPL-3.0": [
-        "GNU Affero General Public License v3.0",
+    "AGPL-3.0-only": [
+        "GNU Affero General Public License v3.0 only",
+        true
+    ],
+    "AGPL-3.0-or-later": [
+        "GNU Affero General Public License v3.0 or later",
         true
     ],
     "Aladdin": [
@@ -151,20 +155,28 @@
         "Borceux license",
         false
     ],
+    "BSD-1-Clause": [
+        "BSD 1-Clause License",
+        false
+    ],
     "BSD-2-Clause": [
-        "BSD 2-clause \"Simplified\" License",
+        "BSD 2-Clause \"Simplified\" License",
         true
     ],
     "BSD-2-Clause-FreeBSD": [
-        "BSD 2-clause FreeBSD License",
+        "BSD 2-Clause FreeBSD License",
         false
     ],
     "BSD-2-Clause-NetBSD": [
-        "BSD 2-clause NetBSD License",
+        "BSD 2-Clause NetBSD License",
         false
     ],
+    "BSD-2-Clause-Patent": [
+        "BSD-2-Clause Plus Patent License",
+        true
+    ],
     "BSD-3-Clause": [
-        "BSD 3-clause \"New\" or \"Revised\" License",
+        "BSD 3-Clause \"New\" or \"Revised\" License",
         true
     ],
     "BSD-3-Clause-Attribution": [
@@ -172,7 +184,7 @@
         false
     ],
     "BSD-3-Clause-Clear": [
-        "BSD 3-clause Clear License",
+        "BSD 3-Clause Clear License",
         false
     ],
     "BSD-3-Clause-LBNL": [
@@ -192,7 +204,7 @@
         false
     ],
     "BSD-4-Clause": [
-        "BSD 4-clause \"Original\" or \"Old\" License",
+        "BSD 4-Clause \"Original\" or \"Old\" License",
         false
     ],
     "BSD-4-Clause-UC": [
@@ -359,6 +371,14 @@
         "Common Development and Distribution License 1.1",
         false
     ],
+    "CDLA-Permissive-1.0": [
+        "Community Data License Agreement Permissive 1.0",
+        false
+    ],
+    "CDLA-Sharing-1.0": [
+        "Community Data License Agreement Sharing 1.0",
+        false
+    ],
     "CECILL-1.0": [
         "CeCILL Free Software License Agreement v1.0",
         false
@@ -487,6 +507,10 @@
         "Eclipse Public License 1.0",
         true
     ],
+    "EPL-2.0": [
+        "Eclipse Public License 2.0",
+        true
+    ],
     "ErlPL-1.1": [
         "Erlang Public License v1.1",
         false
@@ -501,6 +525,10 @@
     ],
     "EUPL-1.1": [
         "European Union Public License 1.1",
+        true
+    ],
+    "EUPL-1.2": [
+        "European Union Public License 1.2",
         true
     ],
     "Eurosym": [
@@ -535,16 +563,28 @@
         "Freetype Project License",
         false
     ],
-    "GFDL-1.1": [
-        "GNU Free Documentation License v1.1",
+    "GFDL-1.1-only": [
+        "GNU Free Documentation License v1.1 only",
         false
     ],
-    "GFDL-1.2": [
-        "GNU Free Documentation License v1.2",
+    "GFDL-1.1-or-later": [
+        "GNU Free Documentation License v1.1 or later",
         false
     ],
-    "GFDL-1.3": [
-        "GNU Free Documentation License v1.3",
+    "GFDL-1.2-only": [
+        "GNU Free Documentation License v1.2 only",
+        false
+    ],
+    "GFDL-1.2-or-later": [
+        "GNU Free Documentation License v1.2 or later",
+        false
+    ],
+    "GFDL-1.3-only": [
+        "GNU Free Documentation License v1.3 only",
+        false
+    ],
+    "GFDL-1.3-or-later": [
+        "GNU Free Documentation License v1.3 or later",
         false
     ],
     "Giftware": [
@@ -567,16 +607,28 @@
         "gnuplot License",
         false
     ],
-    "GPL-1.0": [
+    "GPL-1.0-only": [
         "GNU General Public License v1.0 only",
         false
     ],
-    "GPL-2.0": [
+    "GPL-1.0-or-later": [
+        "GNU General Public License v1.0 or later",
+        false
+    ],
+    "GPL-2.0-only": [
         "GNU General Public License v2.0 only",
         true
     ],
-    "GPL-3.0": [
+    "GPL-2.0-or-later": [
+        "GNU General Public License v2.0 or later",
+        true
+    ],
+    "GPL-3.0-only": [
         "GNU General Public License v3.0 only",
+        true
+    ],
+    "GPL-3.0-or-later": [
+        "GNU General Public License v3.0 or later",
         true
     ],
     "gSOAP-1.3b": [
@@ -588,7 +640,7 @@
         false
     ],
     "HPND": [
-        "Historic Permission Notice and Disclaimer",
+        "Historical Permission Notice and Disclaimer",
         true
     ],
     "IBM-pibs": [
@@ -667,16 +719,28 @@
         "Leptonica License",
         false
     ],
-    "LGPL-2.0": [
+    "LGPL-2.0-only": [
         "GNU Library General Public License v2 only",
         true
     ],
-    "LGPL-2.1": [
+    "LGPL-2.0-or-later": [
+        "GNU Library General Public License v2 or later",
+        true
+    ],
+    "LGPL-2.1-only": [
         "GNU Lesser General Public License v2.1 only",
         true
     ],
-    "LGPL-3.0": [
+    "LGPL-2.1-or-later": [
+        "GNU Lesser General Public License v2.1 or later",
+        true
+    ],
+    "LGPL-3.0-only": [
         "GNU Lesser General Public License v3.0 only",
+        true
+    ],
+    "LGPL-3.0-or-later": [
+        "GNU Lesser General Public License v3.0 or later",
         true
     ],
     "LGPLLR": [
@@ -736,7 +800,7 @@
         false
     ],
     "MirOS": [
-        "MirOS Licence",
+        "MirOS License",
         true
     ],
     "MIT": [
@@ -879,10 +943,6 @@
         "NTP License",
         true
     ],
-    "Nunit": [
-        "Nunit License",
-        false
-    ],
     "OCCT-PL": [
         "Open CASCADE Technology Public License",
         false
@@ -944,7 +1004,7 @@
         false
     ],
     "OLDAP-2.2.2": [
-        "Open LDAP Public License  2.2.2",
+        "Open LDAP Public License 2.2.2",
         false
     ],
     "OLDAP-2.3": [

--- a/src/SpdxLicensesUpdater.php
+++ b/src/SpdxLicensesUpdater.php
@@ -23,7 +23,7 @@ class SpdxLicensesUpdater
      * @param string $file
      * @param string $url
      */
-    public function dumpLicenses($file = null, $url = 'https://spdx.org/licenses/index.html')
+    public function dumpLicenses($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/v2.6/json/licenses.json')
     {
         if (null === $file) {
             $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE;
@@ -47,7 +47,7 @@ class SpdxLicensesUpdater
      * @param string $file
      * @param string $url
      */
-    public function dumpExceptions($file = null, $url = 'https://spdx.org/licenses/exceptions-index.html')
+    public function dumpExceptions($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/v2.6/json/exceptions.json')
     {
         if (null === $file) {
             $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::EXCEPTIONS_FILE;
@@ -76,27 +76,15 @@ class SpdxLicensesUpdater
     {
         $licenses = array();
 
-        $dom = new \DOMDocument();
-        @$dom->loadHTMLFile($url); /* use silence operator to ignore warnings about invalid dom content */
+        $data = json_decode(file_get_contents($url), true);
 
-        $xPath = new \DOMXPath($dom);
-        $trs = $xPath->query('//table//tbody//tr');
-
-        /** @var \DOMElement $tr */
-        foreach ($trs as $tr) {
-            $tds = $tr->getElementsByTagName('td');
-
-            if ($tds->length !== 4) {
+        foreach ($data['licenses'] as $info) {
+            if ($info['isDeprecatedLicenseId']) {
                 continue;
             }
-
-            if ('License Text' === trim($tds->item(3)->nodeValue)) {
-                $fullname = trim($tds->item(0)->nodeValue);
-                $identifier = trim($tds->item(1)->nodeValue);
-                $osiApproved = ((isset($tds->item(2)->nodeValue) && $tds->item(2)->nodeValue === 'Y')) ? true : false;
-
-                $licenses += array($identifier => array($fullname, $osiApproved));
-            }
+            $licenses[$info['licenseId']] = array(
+                trim($info['name']), $info['isOsiApproved']
+            );
         }
 
         uksort($licenses, 'strcasecmp');
@@ -113,26 +101,10 @@ class SpdxLicensesUpdater
     {
         $exceptions = array();
 
-        $dom = new \DOMDocument();
-        @$dom->loadHTMLFile($url); /* use silence operator to ignore warnings about invalid dom content */
+        $data = json_decode(file_get_contents($url), true);
 
-        $xPath = new \DOMXPath($dom);
-        $trs = $xPath->query('//table//tbody//tr');
-
-        /** @var \DOMElement $tr */
-        foreach ($trs as $tr) {
-            $tds = $tr->getElementsByTagName('td');
-
-            if ($tds->length !== 3) {
-                continue;
-            }
-
-            if ('License Exception Text' === trim($tds->item(2)->nodeValue)) {
-                $fullname = trim($tds->item(0)->nodeValue);
-                $identifier = trim($tds->item(1)->nodeValue);
-
-                $exceptions += array($identifier => array($fullname));
-            }
+        foreach ($data['exceptions'] as $info) {
+            $exceptions[$info['licenseExceptionId']] = array(trim($info['name']));
         }
 
         uksort($exceptions, 'strcasecmp');

--- a/src/SpdxLicensesUpdater.php
+++ b/src/SpdxLicensesUpdater.php
@@ -23,7 +23,7 @@ class SpdxLicensesUpdater
      * @param string $file
      * @param string $url
      */
-    public function dumpLicenses($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/v2.6/json/licenses.json')
+    public function dumpLicenses($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')
     {
         if (null === $file) {
             $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE;
@@ -47,7 +47,7 @@ class SpdxLicensesUpdater
      * @param string $file
      * @param string $url
      */
-    public function dumpExceptions($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/v2.6/json/exceptions.json')
+    public function dumpExceptions($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions.json')
     {
         if (null === $file) {
             $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::EXCEPTIONS_FILE;

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -156,7 +156,7 @@ class SpdxLicensesTest extends TestCase
         $identifier = $this->licenses->getIdentifierByName('Affero General Public License v1.0');
         $this->assertEquals($identifier, 'AGPL-1.0');
 
-        $identifier = $this->licenses->getIdentifierByName('BSD 2-clause "Simplified" License');
+        $identifier = $this->licenses->getIdentifierByName('BSD 2-Clause "Simplified" License');
         $this->assertEquals($identifier, 'BSD-2-Clause');
 
         $identifier = $this->licenses->getIdentifierByName('Font exception 2.0');
@@ -203,16 +203,16 @@ class SpdxLicensesTest extends TestCase
                 'NONE',
                 'NOASSERTION',
                 'LicenseRef-3',
-                array('LGPL-2.0', 'GPL-3.0+'),
-                '(LGPL-2.0 or GPL-3.0+)',
-                '(LGPL-2.0 OR GPL-3.0+)',
-                array('EUDatagrid and GPL-3.0+'),
-                '(EUDatagrid and GPL-3.0+)',
-                '(EUDatagrid AND GPL-3.0+)',
-                'GPL-2.0 with Autoconf-exception-2.0',
-                'GPL-2.0 WITH Autoconf-exception-2.0',
-                'GPL-2.0+ WITH Autoconf-exception-2.0',
-                array('(GPL-3.0 and GPL-2.0 or GPL-3.0+)'),
+                array('LGPL-2.0-only', 'GPL-3.0-or-later'),
+                '(LGPL-2.0-only or GPL-3.0-or-later)',
+                '(LGPL-2.0-only OR GPL-3.0-or-later)',
+                array('EUDatagrid and GPL-3.0-or-later'),
+                '(EUDatagrid and GPL-3.0-or-later)',
+                '(EUDatagrid AND GPL-3.0-or-later)',
+                'GPL-2.0-only with Autoconf-exception-2.0',
+                'GPL-2.0-only WITH Autoconf-exception-2.0',
+                'GPL-2.0-or-later WITH Autoconf-exception-2.0',
+                array('(GPL-3.0-only and GPL-2.0-only or GPL-3.0-or-later)'),
             ),
             $identifiers
         );
@@ -240,10 +240,10 @@ class SpdxLicensesTest extends TestCase
             array('MIT AND NONE'),
             array('MIT (MIT and MIT)'),
             array('(MIT and MIT) MIT'),
-            array(array('LGPL-2.0', 'The system pwns you')),
-            array('and GPL-3.0+'),
-            array('(EUDatagrid and GPL-3.0+ and  )'),
-            array('(EUDatagrid xor GPL-3.0+)'),
+            array(array('LGPL-2.0-only', 'The system pwns you')),
+            array('and GPL-3.0-or-later'),
+            array('(EUDatagrid and GPL-3.0-or-later and  )'),
+            array('(EUDatagrid xor GPL-3.0-or-later)'),
             array('(MIT Or MIT)'),
             array('(NONE or MIT)'),
             array('(NOASSERTION or MIT)'),


### PR DESCRIPTION
Notably, the GNU licenses now have `-only` or `-or-later` suffixes.

In addition, I covered the updater to the JSON data files instead of screen-scraping from the SPDX website.

One question I had was whether we need to keep backwards-compatibility with the older license names, and include the deprecated license names?