### PR TITLE
Retrieve list of license identifiers and names

### DIFF
--- a/src/SpdxLicenses.php
+++ b/src/SpdxLicenses.php
@@ -91,6 +91,16 @@ class SpdxLicenses
     }
 
     /**
+     * Returns all licenses information, keyed by the license identifier.
+     *
+     * @return array
+     */
+    public function getLicenses()
+    {
+        return $this->licenses;
+    }
+
+    /**
      * Returns license exception metadata by license exception identifier.
      *
      * This function adds a link to the full license exception text to the license exception metadata.

--- a/src/SpdxLicenses.php
+++ b/src/SpdxLicenses.php
@@ -25,8 +25,8 @@ class SpdxLicenses
      * The array is indexed by license identifiers, which contain
      * a numerically indexed array with license details.
      *
-     *  [ license identifier =>
-     *      [ 0 => full name (string), 1 => osi certified (bool), 2 => deprecated (bool) ]
+     *  [ lowercased license identifier =>
+     *      [ 0 => identifier (string), 1 => full name (string), 2 => osi certified (bool), 3 => deprecated (bool) ]
      *    , ...
      *  ]
      *
@@ -45,8 +45,8 @@ class SpdxLicenses
      * The array is indexed by license exception identifiers, which contain
      * a numerically indexed array with license exception details.
      *
-     *  [ exception identifier =>
-     *      [ 0 => full name (string) ]
+     *  [ lowercased exception identifier =>
+     *      [ 0 => exception identifier (string), 1 => full name (string) ]
      *    , ...
      *  ]
      *
@@ -91,9 +91,9 @@ class SpdxLicenses
     }
 
     /**
-     * Returns all licenses information, keyed by the license identifier.
+     * Returns all licenses information, keyed by the lowercased license identifier.
      *
-     * @return array
+     * @return array[] Each item is [ 0 => identifier (string), 1 => full name (string), 2 => osi certified (bool), 3 => deprecated (bool) ]
      */
     public function getLicenses()
     {

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -142,6 +142,15 @@ class SpdxLicensesTest extends TestCase
         $this->assertNull($licenseNull);
     }
 
+    public function testGetLicenses()
+    {
+        $results = $this->licenses->getLicenses();
+
+        $this->assertArrayHasKey('CC-BY-SA-4.0', $results);
+        $this->assertArrayHasKey(0, $results['CC-BY-SA-4.0']);
+        $this->assertEquals($results['CC-BY-SA-4.0'][0], 'Creative Commons Attribution Share Alike 4.0');
+    }
+
     public function testGetExceptionByIdentifier()
     {
         $licenseNull = $this->licenses->getExceptionByIdentifier('Font-exception-2.0-Errorl');

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -146,9 +146,12 @@ class SpdxLicensesTest extends TestCase
     {
         $results = $this->licenses->getLicenses();
 
-        $this->assertArrayHasKey('CC-BY-SA-4.0', $results);
-        $this->assertArrayHasKey(0, $results['CC-BY-SA-4.0']);
-        $this->assertEquals($results['CC-BY-SA-4.0'][0], 'Creative Commons Attribution Share Alike 4.0');
+        $this->assertArrayHasKey('cc-by-sa-4.0', $results);
+        $this->assertArrayHasKey(0, $results['cc-by-sa-4.0']);
+        $this->assertEquals('CC-BY-SA-4.0', $results['cc-by-sa-4.0'][0]);
+        $this->assertEquals('Creative Commons Attribution Share Alike 4.0', $results['cc-by-sa-4.0'][1]);
+        $this->assertEquals(false, $results['cc-by-sa-4.0'][2]);
+        $this->assertEquals(false, $results['cc-by-sa-4.0'][3]);
     }
 
     public function testGetExceptionByIdentifier()


### PR DESCRIPTION
This PR implements `getLicensesList()` method and adds the corresponding test.

The method allows us to retrieve a list of all loaded identifiers. The
result of the method can be used for i.e. driving a select input
field where end users pick a valid license.