### PR TITLE
Update to SPDX 3.1

### DIFF
--- a/res/spdx-exceptions.json
+++ b/res/spdx-exceptions.json
@@ -56,6 +56,9 @@
     "Linux-syscall-note": [
         "Linux Syscall Note"
     ],
+    "LLVM-exception": [
+        "LLVM Exception"
+    ],
     "LZMA-exception": [
         "LZMA exception"
     ],
@@ -67,6 +70,9 @@
     ],
     "OCCT-exception-1.0": [
         "Open CASCADE Exception 1.0"
+    ],
+    "OpenJDK-assembly-exception-1.0": [
+        "OpenJDK Assembly exception 1.0"
     ],
     "openvpn-openssl-exception": [
         "OpenVPN OpenSSL Exception"

--- a/res/spdx-licenses.json
+++ b/res/spdx-licenses.json
@@ -62,6 +62,16 @@
     "AGPL-1.0": [
         "Affero General Public License v1.0",
         false,
+        true
+    ],
+    "AGPL-1.0-only": [
+        "Affero General Public License v1.0 only",
+        false,
+        false
+    ],
+    "AGPL-1.0-or-later": [
+        "Affero General Public License v1.0 or later",
+        false,
         false
     ],
     "AGPL-3.0": [
@@ -305,152 +315,152 @@
         false
     ],
     "CC-BY-1.0": [
-        "Creative Commons Attribution 1.0",
+        "Creative Commons Attribution 1.0 Generic",
         false,
         false
     ],
     "CC-BY-2.0": [
-        "Creative Commons Attribution 2.0",
+        "Creative Commons Attribution 2.0 Generic",
         false,
         false
     ],
     "CC-BY-2.5": [
-        "Creative Commons Attribution 2.5",
+        "Creative Commons Attribution 2.5 Generic",
         false,
         false
     ],
     "CC-BY-3.0": [
-        "Creative Commons Attribution 3.0",
+        "Creative Commons Attribution 3.0 Unported",
         false,
         false
     ],
     "CC-BY-4.0": [
-        "Creative Commons Attribution 4.0",
+        "Creative Commons Attribution 4.0 International",
         false,
         false
     ],
     "CC-BY-NC-1.0": [
-        "Creative Commons Attribution Non Commercial 1.0",
+        "Creative Commons Attribution Non Commercial 1.0 Generic",
         false,
         false
     ],
     "CC-BY-NC-2.0": [
-        "Creative Commons Attribution Non Commercial 2.0",
+        "Creative Commons Attribution Non Commercial 2.0 Generic",
         false,
         false
     ],
     "CC-BY-NC-2.5": [
-        "Creative Commons Attribution Non Commercial 2.5",
+        "Creative Commons Attribution Non Commercial 2.5 Generic",
         false,
         false
     ],
     "CC-BY-NC-3.0": [
-        "Creative Commons Attribution Non Commercial 3.0",
+        "Creative Commons Attribution Non Commercial 3.0 Unported",
         false,
         false
     ],
     "CC-BY-NC-4.0": [
-        "Creative Commons Attribution Non Commercial 4.0",
+        "Creative Commons Attribution Non Commercial 4.0 International",
         false,
         false
     ],
     "CC-BY-NC-ND-1.0": [
-        "Creative Commons Attribution Non Commercial No Derivatives 1.0",
+        "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
         false,
         false
     ],
     "CC-BY-NC-ND-2.0": [
-        "Creative Commons Attribution Non Commercial No Derivatives 2.0",
+        "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
         false,
         false
     ],
     "CC-BY-NC-ND-2.5": [
-        "Creative Commons Attribution Non Commercial No Derivatives 2.5",
+        "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
         false,
         false
     ],
     "CC-BY-NC-ND-3.0": [
-        "Creative Commons Attribution Non Commercial No Derivatives 3.0",
+        "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
         false,
         false
     ],
     "CC-BY-NC-ND-4.0": [
-        "Creative Commons Attribution Non Commercial No Derivatives 4.0",
+        "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
         false,
         false
     ],
     "CC-BY-NC-SA-1.0": [
-        "Creative Commons Attribution Non Commercial Share Alike 1.0",
+        "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
         false,
         false
     ],
     "CC-BY-NC-SA-2.0": [
-        "Creative Commons Attribution Non Commercial Share Alike 2.0",
+        "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
         false,
         false
     ],
     "CC-BY-NC-SA-2.5": [
-        "Creative Commons Attribution Non Commercial Share Alike 2.5",
+        "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
         false,
         false
     ],
     "CC-BY-NC-SA-3.0": [
-        "Creative Commons Attribution Non Commercial Share Alike 3.0",
+        "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
         false,
         false
     ],
     "CC-BY-NC-SA-4.0": [
-        "Creative Commons Attribution Non Commercial Share Alike 4.0",
+        "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
         false,
         false
     ],
     "CC-BY-ND-1.0": [
-        "Creative Commons Attribution No Derivatives 1.0",
+        "Creative Commons Attribution No Derivatives 1.0 Generic",
         false,
         false
     ],
     "CC-BY-ND-2.0": [
-        "Creative Commons Attribution No Derivatives 2.0",
+        "Creative Commons Attribution No Derivatives 2.0 Generic",
         false,
         false
     ],
     "CC-BY-ND-2.5": [
-        "Creative Commons Attribution No Derivatives 2.5",
+        "Creative Commons Attribution No Derivatives 2.5 Generic",
         false,
         false
     ],
     "CC-BY-ND-3.0": [
-        "Creative Commons Attribution No Derivatives 3.0",
+        "Creative Commons Attribution No Derivatives 3.0 Unported",
         false,
         false
     ],
     "CC-BY-ND-4.0": [
-        "Creative Commons Attribution No Derivatives 4.0",
+        "Creative Commons Attribution No Derivatives 4.0 International",
         false,
         false
     ],
     "CC-BY-SA-1.0": [
-        "Creative Commons Attribution Share Alike 1.0",
+        "Creative Commons Attribution Share Alike 1.0 Generic",
         false,
         false
     ],
     "CC-BY-SA-2.0": [
-        "Creative Commons Attribution Share Alike 2.0",
+        "Creative Commons Attribution Share Alike 2.0 Generic",
         false,
         false
     ],
     "CC-BY-SA-2.5": [
-        "Creative Commons Attribution Share Alike 2.5",
+        "Creative Commons Attribution Share Alike 2.5 Generic",
         false,
         false
     ],
     "CC-BY-SA-3.0": [
-        "Creative Commons Attribution Share Alike 3.0",
+        "Creative Commons Attribution Share Alike 3.0 Unported",
         false,
         false
     ],
     "CC-BY-SA-4.0": [
-        "Creative Commons Attribution Share Alike 4.0",
+        "Creative Commons Attribution Share Alike 4.0 International",
         false,
         false
     ],
@@ -1015,7 +1025,7 @@
         true
     ],
     "LGPL-2.1+": [
-        "GNU Library General Public License v2 or later",
+        "GNU Library General Public License v2.1 or later",
         true,
         true
     ],
@@ -1079,6 +1089,11 @@
         true,
         false
     ],
+    "Linux-OpenIB": [
+        "Linux Kernel Variant of OpenIB.org license",
+        false,
+        false
+    ],
     "LPL-1.0": [
         "Lucent Public License Version 1.0",
         true,
@@ -1126,6 +1141,11 @@
     ],
     "MIT": [
         "MIT License",
+        true,
+        false
+    ],
+    "MIT-0": [
+        "MIT No Attribution",
         true,
         false
     ],

--- a/tests/SpdxLicensesTest.php
+++ b/tests/SpdxLicensesTest.php
@@ -132,8 +132,8 @@ class SpdxLicensesTest extends TestCase
 
     public function testGetLicenseByIdentifier()
     {
-        $license = $this->licenses->getLicenseByIdentifier('AGPL-1.0');
-        $this->assertEquals('Affero General Public License v1.0', $license[0]);
+        $license = $this->licenses->getLicenseByIdentifier('AGPL-1.0-only');
+        $this->assertEquals('Affero General Public License v1.0 only', $license[0]);
         $this->assertFalse($license[1]);
         $this->assertStringStartsWith('https://spdx.org/licenses/', $license[2]);
         $this->assertFalse($license[3]);
@@ -149,7 +149,7 @@ class SpdxLicensesTest extends TestCase
         $this->assertArrayHasKey('cc-by-sa-4.0', $results);
         $this->assertArrayHasKey(0, $results['cc-by-sa-4.0']);
         $this->assertEquals('CC-BY-SA-4.0', $results['cc-by-sa-4.0'][0]);
-        $this->assertEquals('Creative Commons Attribution Share Alike 4.0', $results['cc-by-sa-4.0'][1]);
+        $this->assertEquals('Creative Commons Attribution Share Alike 4.0 International', $results['cc-by-sa-4.0'][1]);
         $this->assertEquals(false, $results['cc-by-sa-4.0'][2]);
         $this->assertEquals(false, $results['cc-by-sa-4.0'][3]);
     }


### PR DESCRIPTION
https://lists.spdx.org/pipermail/spdx-legal/2018-April/002554.html

No major changes, a few renames, new licenses and deprecation of `AGPL-1.0` in favor of `-only`/`-or-later` versions.