### PR TITLE
Update to SPDX 3.4

### DIFF
--- a/res/spdx-licenses.json
+++ b/res/spdx-licenses.json
@@ -1,7 +1,7 @@
 {
     "0BSD": [
         "BSD Zero Clause License",
-        false,
+        true,
         false
     ],
     "AAL": [
@@ -541,6 +541,11 @@
     ],
     "Condor-1.1": [
         "Condor Public License v1.1",
+        false,
+        false
+    ],
+    "copyleft-next-0.3.0": [
+        "copyleft-next 0.3.0",
         false,
         false
     ],


### PR DESCRIPTION
Added copyleft-next-0.3.0 license, no removals.

Release notes are available at <https://github.com/spdx/license-list-XML/blob/master/RELEASE-NOTES.md#version-34---2018-12-20>.