### PR TITLE
[PHP 8.2] Fix deprecated string interpolation patterns

### DIFF
--- a/src/SpdxLicenses.php
+++ b/src/SpdxLicenses.php
@@ -309,10 +309,10 @@ class SpdxLicenses
     (?<idstring>[\pL\pN.-]{1,})
 
     # license-id: taken from list
-    (?<licenseid>${licenses})
+    (?<licenseid>{$licenses})
 
     # license-exception-id: taken from list
-    (?<licenseexceptionid>${exceptions})
+    (?<licenseexceptionid>{$exceptions})
 
     # license-ref: [DocumentRef-1*(idstring):]LicenseRef-1*(idstring)
     (?<licenseref>(?:DocumentRef-(?&idstring):)?LicenseRef-(?&idstring))


### PR DESCRIPTION
PHP 8.2 deprecates string interpolation patterns that place the dollar sign outside the curly braces. This fixes such patterns by replacing them with proper curly braced patterns.

 - [PHP.Watch: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated)
 - [wiki.php.net RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)
 - [Related change in composer/composer#10766](https://github.com/composer/composer/pull/10766)