### PR TITLE
chore(spdx-list): update license list to SPDX 3.22

### DIFF
--- a/res/spdx-exceptions.json
+++ b/res/spdx-exceptions.json
@@ -2,11 +2,23 @@
     "389-exception": [
         "389 Directory Server Exception"
     ],
+    "Asterisk-exception": [
+        "Asterisk exception"
+    ],
     "Autoconf-exception-2.0": [
         "Autoconf exception 2.0"
     ],
     "Autoconf-exception-3.0": [
         "Autoconf exception 3.0"
+    ],
+    "Autoconf-exception-generic": [
+        "Autoconf generic exception"
+    ],
+    "Autoconf-exception-generic-3.0": [
+        "Autoconf generic exception for GPL-3.0"
+    ],
+    "Autoconf-exception-macro": [
+        "Autoconf macro exception"
     ],
     "Bison-exception-2.2": [
         "Bison exception 2.2"
@@ -19,6 +31,9 @@
     ],
     "CLISP-exception-2.0": [
         "CLISP exception 2.0"
+    ],
+    "cryptsetup-OpenSSL-exception": [
+        "cryptsetup OpenSSL exception"
     ],
     "DigiRule-FOSS-exception": [
         "DigiRule FOSS License Exception"
@@ -41,11 +56,23 @@
     "GCC-exception-2.0": [
         "GCC Runtime Library exception 2.0"
     ],
+    "GCC-exception-2.0-note": [
+        "GCC    Runtime Library exception 2.0 - note variant"
+    ],
     "GCC-exception-3.1": [
         "GCC Runtime Library exception 3.1"
     ],
+    "GNAT-exception": [
+        "GNAT exception"
+    ],
+    "GNU-compiler-exception": [
+        "GNU Compiler Exception"
+    ],
     "gnu-javamail-exception": [
         "GNU JavaMail exception"
+    ],
+    "GPL-3.0-interface-exception": [
+        "GPL-3.0 Interface Exception"
     ],
     "GPL-3.0-linking-exception": [
         "GPL-3.0 Linking Exception"
@@ -56,17 +83,32 @@
     "GPL-CC-1.0": [
         "GPL Cooperation Commitment 1.0"
     ],
+    "GStreamer-exception-2005": [
+        "GStreamer Exception (2005)"
+    ],
+    "GStreamer-exception-2008": [
+        "GStreamer Exception (2008)"
+    ],
     "i2p-gpl-java-exception": [
         "i2p GPL+Java Exception"
     ],
+    "KiCad-libraries-exception": [
+        "KiCad Libraries Exception"
+    ],
     "LGPL-3.0-linking-exception": [
         "LGPL-3.0 Linking Exception"
+    ],
+    "libpri-OpenH323-exception": [
+        "libpri OpenH323 exception"
     ],
     "Libtool-exception": [
         "Libtool Exception"
     ],
     "Linux-syscall-note": [
         "Linux Syscall Note"
+    ],
+    "LLGPL": [
+        "LLGPL Preamble"
     ],
     "LLVM-exception": [
         "LLVM Exception"
@@ -95,6 +137,9 @@
     "PS-or-PDF-font-exception-20170817": [
         "PS/PDF font exception (2017-08-17)"
     ],
+    "QPL-1.0-INRIA-2004-exception": [
+        "INRIA QPL 1.0 2004 variant exception"
+    ],
     "Qt-GPL-exception-1.0": [
         "Qt GPL exception 1.0"
     ],
@@ -104,22 +149,43 @@
     "Qwt-exception-1.0": [
         "Qwt exception 1.0"
     ],
+    "SANE-exception": [
+        "SANE Exception"
+    ],
     "SHL-2.0": [
         "Solderpad Hardware License v2.0"
     ],
     "SHL-2.1": [
         "Solderpad Hardware License v2.1"
     ],
+    "stunnel-exception": [
+        "stunnel Exception"
+    ],
+    "SWI-exception": [
+        "SWI exception"
+    ],
     "Swift-exception": [
         "Swift Exception"
+    ],
+    "Texinfo-exception": [
+        "Texinfo exception"
     ],
     "u-boot-exception-2.0": [
         "U-Boot exception 2.0"
     ],
+    "UBDL-exception": [
+        "Unmodified Binary Distribution exception"
+    ],
     "Universal-FOSS-exception-1.0": [
         "Universal FOSS Exception, Version 1.0"
     ],
+    "vsftpd-openssl-exception": [
+        "vsftpd OpenSSL exception"
+    ],
     "WxWindows-exception-3.1": [
         "WxWindows Library Exception 3.1"
+    ],
+    "x11vnc-openssl-exception": [
+        "x11vnc OpenSSL Exception"
     ]
 }

--- a/res/spdx-licenses.json
+++ b/res/spdx-licenses.json
@@ -14,13 +14,28 @@
         false,
         false
     ],
+    "AdaCore-doc": [
+        "AdaCore Doc License",
+        false,
+        false
+    ],
     "Adobe-2006": [
         "Adobe Systems Incorporated Source Code License Agreement",
         false,
         false
     ],
+    "Adobe-Display-PostScript": [
+        "Adobe Display PostScript License",
+        false,
+        false
+    ],
     "Adobe-Glyph": [
         "Adobe Glyph List License",
+        false,
+        false
+    ],
+    "Adobe-Utopia": [
+        "Adobe Utopia Font License",
         false,
         false
     ],
@@ -101,6 +116,11 @@
     ],
     "AML": [
         "Apple MIT License",
+        false,
+        false
+    ],
+    "AML-glslang": [
+        "AML glslang variant License",
         false,
         false
     ],
@@ -194,6 +214,16 @@
         true,
         false
     ],
+    "ASWF-Digital-Assets-1.0": [
+        "ASWF Digital Assets License version 1.0",
+        false,
+        false
+    ],
+    "ASWF-Digital-Assets-1.1": [
+        "ASWF Digital Assets License 1.1",
+        false,
+        false
+    ],
     "Baekmuk": [
         "Baekmuk License",
         false,
@@ -211,6 +241,11 @@
     ],
     "Beerware": [
         "Beerware License",
+        false,
+        false
+    ],
+    "Bitstream-Charter": [
+        "Bitstream Charter Font License",
         false,
         false
     ],
@@ -239,8 +274,18 @@
         false,
         false
     ],
+    "Boehm-GC": [
+        "Boehm-Demers-Weiser GC License",
+        false,
+        false
+    ],
     "Borceux": [
         "Borceux license",
+        false,
+        false
+    ],
+    "Brian-Gladman-3-Clause": [
+        "Brian Gladman 3-Clause License",
         false,
         false
     ],
@@ -289,6 +334,16 @@
         false,
         false
     ],
+    "BSD-3-Clause-flex": [
+        "BSD 3-Clause Flex variant",
+        false,
+        false
+    ],
+    "BSD-3-Clause-HP": [
+        "Hewlett-Packard BSD variant license",
+        false,
+        false
+    ],
     "BSD-3-Clause-LBNL": [
         "Lawrence Berkeley National Labs BSD variant license",
         true,
@@ -324,6 +379,11 @@
         false,
         false
     ],
+    "BSD-3-Clause-Sun": [
+        "BSD 3-Clause Sun Microsystems",
+        false,
+        false
+    ],
     "BSD-4-Clause": [
         "BSD 4-Clause \"Original\" or \"Old\" License",
         false,
@@ -339,6 +399,31 @@
         false,
         false
     ],
+    "BSD-4.3RENO": [
+        "BSD 4.3 RENO License",
+        false,
+        false
+    ],
+    "BSD-4.3TAHOE": [
+        "BSD 4.3 TAHOE License",
+        false,
+        false
+    ],
+    "BSD-Advertising-Acknowledgement": [
+        "BSD Advertising Acknowledgement License",
+        false,
+        false
+    ],
+    "BSD-Attribution-HPND-disclaimer": [
+        "BSD with Attribution and HPND disclaimer",
+        false,
+        false
+    ],
+    "BSD-Inferno-Nettverk": [
+        "BSD-Inferno-Nettverk",
+        false,
+        false
+    ],
     "BSD-Protection": [
         "BSD Protection License",
         false,
@@ -346,6 +431,11 @@
     ],
     "BSD-Source-Code": [
         "BSD Source Code Attribution",
+        false,
+        false
+    ],
+    "BSD-Systemics": [
+        "Systemics BSD variant license",
         false,
         false
     ],
@@ -426,6 +516,11 @@
     ],
     "CC-BY-3.0-DE": [
         "Creative Commons Attribution 3.0 Germany",
+        false,
+        false
+    ],
+    "CC-BY-3.0-IGO": [
+        "Creative Commons Attribution 3.0 IGO",
         false,
         false
     ],
@@ -516,6 +611,11 @@
     ],
     "CC-BY-NC-SA-2.0": [
         "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+        false,
+        false
+    ],
+    "CC-BY-NC-SA-2.0-DE": [
+        "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
         false,
         false
     ],
@@ -624,6 +724,11 @@
         false,
         false
     ],
+    "CC-BY-SA-3.0-IGO": [
+        "Creative Commons Attribution-ShareAlike 3.0 IGO",
+        false,
+        false
+    ],
     "CC-BY-SA-4.0": [
         "Creative Commons Attribution Share Alike 4.0 International",
         false,
@@ -724,8 +829,33 @@
         true,
         false
     ],
+    "CFITSIO": [
+        "CFITSIO License",
+        false,
+        false
+    ],
+    "check-cvs": [
+        "check-cvs License",
+        false,
+        false
+    ],
+    "checkmk": [
+        "Checkmk License",
+        false,
+        false
+    ],
     "ClArtistic": [
         "Clarified Artistic License",
+        false,
+        false
+    ],
+    "Clips": [
+        "Clips License",
+        false,
+        false
+    ],
+    "CMU-Mach": [
+        "CMU Mach License",
         false,
         false
     ],
@@ -769,6 +899,11 @@
         false,
         false
     ],
+    "Cornell-Lossless-JPEG": [
+        "Cornell Lossless JPEG License",
+        false,
+        false
+    ],
     "CPAL-1.0": [
         "Common Public Attribution License 1.0",
         true,
@@ -781,6 +916,11 @@
     ],
     "CPOL-1.02": [
         "Code Project Open License 1.02",
+        false,
+        false
+    ],
+    "Cronyx": [
+        "Cronyx License",
         false,
         false
     ],
@@ -814,6 +954,11 @@
         false,
         false
     ],
+    "DEC-3-Clause": [
+        "DEC 3-Clause License",
+        false,
+        false
+    ],
     "diffmark": [
         "diffmark license",
         false,
@@ -821,6 +966,11 @@
     ],
     "DL-DE-BY-2.0": [
         "Data licence Germany \u2013 attribution \u2013 version 2.0",
+        false,
+        false
+    ],
+    "DL-DE-ZERO-2.0": [
+        "Data licence Germany \u2013 zero \u2013 version 2.0",
         false,
         false
     ],
@@ -839,8 +989,18 @@
         false,
         false
     ],
+    "DRL-1.1": [
+        "Detection Rule License 1.1",
+        false,
+        false
+    ],
     "DSDP": [
         "DSDP License",
+        false,
+        false
+    ],
+    "dtoa": [
+        "David M. Gay dtoa License",
         false,
         false
     ],
@@ -944,8 +1104,18 @@
         true,
         false
     ],
+    "FBM": [
+        "Fuzzy Bitmap License",
+        false,
+        false
+    ],
     "FDK-AAC": [
         "Fraunhofer FDK AAC Codec Library",
+        false,
+        false
+    ],
+    "Ferguson-Twofish": [
+        "Ferguson Twofish License",
         false,
         false
     ],
@@ -979,8 +1149,28 @@
         false,
         false
     ],
+    "FSFULLRWD": [
+        "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
+        false,
+        false
+    ],
     "FTL": [
         "Freetype Project License",
+        false,
+        false
+    ],
+    "Furuseth": [
+        "Furuseth License",
+        false,
+        false
+    ],
+    "fwlw": [
+        "fwlw License",
+        false,
+        false
+    ],
+    "GCR-docs": [
+        "Gnome GCR Documentation License",
         false,
         false
     ],
@@ -1219,6 +1409,11 @@
         true,
         true
     ],
+    "Graphics-Gems": [
+        "Graphics Gems License",
+        false,
+        false
+    ],
     "gSOAP-1.3b": [
         "gSOAP Public License v1.3b",
         false,
@@ -1229,8 +1424,23 @@
         false,
         false
     ],
+    "hdparm": [
+        "hdparm License",
+        false,
+        false
+    ],
     "Hippocratic-2.1": [
         "Hippocratic License 2.1",
+        false,
+        false
+    ],
+    "HP-1986": [
+        "Hewlett-Packard 1986 License",
+        false,
+        false
+    ],
+    "HP-1989": [
+        "Hewlett-Packard 1989 License",
         false,
         false
     ],
@@ -1239,8 +1449,63 @@
         true,
         false
     ],
+    "HPND-DEC": [
+        "Historical Permission Notice and Disclaimer - DEC variant",
+        false,
+        false
+    ],
+    "HPND-doc": [
+        "Historical Permission Notice and Disclaimer - documentation variant",
+        false,
+        false
+    ],
+    "HPND-doc-sell": [
+        "Historical Permission Notice and Disclaimer - documentation sell variant",
+        false,
+        false
+    ],
+    "HPND-export-US": [
+        "HPND with US Government export control warning",
+        false,
+        false
+    ],
+    "HPND-export-US-modify": [
+        "HPND with US Government export control warning and modification rqmt",
+        false,
+        false
+    ],
+    "HPND-Markus-Kuhn": [
+        "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
+        false,
+        false
+    ],
+    "HPND-Pbmplus": [
+        "Historical Permission Notice and Disclaimer - Pbmplus variant",
+        false,
+        false
+    ],
+    "HPND-sell-MIT-disclaimer-xserver": [
+        "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
+        false,
+        false
+    ],
+    "HPND-sell-regexpr": [
+        "Historical Permission Notice and Disclaimer - sell regexpr variant",
+        false,
+        false
+    ],
     "HPND-sell-variant": [
         "Historical Permission Notice and Disclaimer - sell variant",
+        false,
+        false
+    ],
+    "HPND-sell-variant-MIT-disclaimer": [
+        "HPND sell variant with MIT disclaimer",
+        false,
+        false
+    ],
+    "HPND-UC": [
+        "Historical Permission Notice and Disclaimer - University of California variant",
         false,
         false
     ],
@@ -1256,11 +1521,21 @@
     ],
     "ICU": [
         "ICU License",
+        true,
+        false
+    ],
+    "IEC-Code-Components-EULA": [
+        "IEC    Code Components End-user licence agreement",
         false,
         false
     ],
     "IJG": [
         "Independent JPEG Group License",
+        false,
+        false
+    ],
+    "IJG-short": [
+        "Independent JPEG Group License - short",
         false,
         false
     ],
@@ -1281,6 +1556,11 @@
     ],
     "Info-ZIP": [
         "Info-ZIP License",
+        false,
+        false
+    ],
+    "Inner-Net-2.0": [
+        "Inner Net License v2.0",
         false,
         false
     ],
@@ -1324,6 +1604,11 @@
         false,
         false
     ],
+    "JPL-image": [
+        "JPL Image Use Policy",
+        false,
+        false
+    ],
     "JPNIC": [
         "Japan Network Information Center License",
         false,
@@ -1334,8 +1619,18 @@
         false,
         false
     ],
-    "KiCad-libraries-exception": [
-        "KiCad Libraries Exception",
+    "Kastrup": [
+        "Kastrup License",
+        false,
+        false
+    ],
+    "Kazlib": [
+        "Kazlib License",
+        false,
+        false
+    ],
+    "Knuth-CTAN": [
+        "Knuth CTAN License",
         false,
         false
     ],
@@ -1351,6 +1646,11 @@
     ],
     "Latex2e": [
         "Latex2e License",
+        false,
+        false
+    ],
+    "Latex2e-translated-notice": [
+        "Latex2e with translated notice permission",
         false,
         false
     ],
@@ -1385,7 +1685,7 @@
         true
     ],
     "LGPL-2.1+": [
-        "GNU Library General Public License v2.1 or later",
+        "GNU Lesser General Public License v2.1 or later",
         true,
         true
     ],
@@ -1444,6 +1744,11 @@
         false,
         false
     ],
+    "libutil-David-Nugent": [
+        "libutil David Nugent License",
+        false,
+        false
+    ],
     "LiLiQ-P-1.1": [
         "Licence Libre du Qu\u00e9bec \u2013 Permissive version 1.1",
         true,
@@ -1459,13 +1764,33 @@
         true,
         false
     ],
+    "Linux-man-pages-1-para": [
+        "Linux man-pages - 1 paragraph",
+        false,
+        false
+    ],
     "Linux-man-pages-copyleft": [
         "Linux man-pages Copyleft",
         false,
         false
     ],
+    "Linux-man-pages-copyleft-2-para": [
+        "Linux man-pages Copyleft - 2 paragraphs",
+        false,
+        false
+    ],
+    "Linux-man-pages-copyleft-var": [
+        "Linux man-pages Copyleft Variant",
+        false,
+        false
+    ],
     "Linux-OpenIB": [
         "Linux Kernel Variant of OpenIB.org license",
+        false,
+        false
+    ],
+    "LOOP": [
+        "Common Lisp LOOP License",
         false,
         false
     ],
@@ -1504,8 +1829,53 @@
         true,
         false
     ],
+    "lsof": [
+        "lsof License",
+        false,
+        false
+    ],
+    "Lucida-Bitmap-Fonts": [
+        "Lucida Bitmap Fonts License",
+        false,
+        false
+    ],
+    "LZMA-SDK-9.11-to-9.20": [
+        "LZMA SDK License (versions 9.11 to 9.20)",
+        false,
+        false
+    ],
+    "LZMA-SDK-9.22": [
+        "LZMA SDK License (versions 9.22 and beyond)",
+        false,
+        false
+    ],
+    "magaz": [
+        "magaz License",
+        false,
+        false
+    ],
     "MakeIndex": [
         "MakeIndex License",
+        false,
+        false
+    ],
+    "Martin-Birgmeier": [
+        "Martin Birgmeier License",
+        false,
+        false
+    ],
+    "McPhee-slideshow": [
+        "McPhee Slideshow License",
+        false,
+        false
+    ],
+    "metamail": [
+        "metamail License",
+        false,
+        false
+    ],
+    "Minpack": [
+        "Minpack License",
         false,
         false
     ],
@@ -1544,6 +1914,11 @@
         false,
         false
     ],
+    "MIT-Festival": [
+        "MIT Festival Variant",
+        false,
+        false
+    ],
     "MIT-Modern-Variant": [
         "MIT License Modern Variant",
         true,
@@ -1554,14 +1929,39 @@
         false,
         false
     ],
+    "MIT-testregex": [
+        "MIT testregex Variant",
+        false,
+        false
+    ],
+    "MIT-Wu": [
+        "MIT Tom Wu Variant",
+        false,
+        false
+    ],
     "MITNFA": [
         "MIT +no-false-attribs license",
+        false,
+        false
+    ],
+    "MMIXware": [
+        "MMIXware License",
         false,
         false
     ],
     "Motosoto": [
         "Motosoto License",
         true,
+        false
+    ],
+    "MPEG-SSG": [
+        "MPEG Software Simulation",
+        false,
+        false
+    ],
+    "mpi-permissive": [
+        "mpi Permissive License",
+        false,
         false
     ],
     "mpich2": [
@@ -1591,6 +1991,11 @@
     ],
     "mplus": [
         "mplus Font License",
+        false,
+        false
+    ],
+    "MS-LPL": [
+        "Microsoft Limited Public License",
         false,
         false
     ],
@@ -1679,6 +2084,11 @@
         true,
         false
     ],
+    "NICTA-1.0": [
+        "NICTA Public Software License, Version 1.0",
+        false,
+        false
+    ],
     "NIST-PD": [
         "NIST Public Domain Notice",
         false,
@@ -1686,6 +2096,11 @@
     ],
     "NIST-PD-fallback": [
         "NIST Public Domain Notice with license fallback",
+        false,
+        false
+    ],
+    "NIST-Software": [
+        "NIST Software License",
         false,
         false
     ],
@@ -1776,6 +2191,11 @@
     ],
     "ODC-By-1.0": [
         "Open Data Commons Attribution License v1.0",
+        false,
+        false
+    ],
+    "OFFIS": [
+        "OFFIS License",
         false,
         false
     ],
@@ -1924,8 +2344,18 @@
         true,
         false
     ],
+    "OLFL-1.3": [
+        "Open Logistics Foundation License Version 1.3",
+        true,
+        false
+    ],
     "OML": [
         "Open Market License",
+        false,
+        false
+    ],
+    "OpenPBS-2.3": [
+        "OpenPBS v2.3 Software License",
         false,
         false
     ],
@@ -1936,6 +2366,11 @@
     ],
     "OPL-1.0": [
         "Open Public License v1.0",
+        false,
+        false
+    ],
+    "OPL-UK-3.0": [
+        "United    Kingdom Open Parliament Licence v3.0",
         false,
         false
     ],
@@ -1974,6 +2409,11 @@
         true,
         false
     ],
+    "PADL": [
+        "PADL License",
+        false,
+        false
+    ],
     "Parity-6.0.0": [
         "The Parity Public License 6.0.0",
         false,
@@ -1999,8 +2439,18 @@
         true,
         false
     ],
+    "Pixar": [
+        "Pixar License",
+        false,
+        false
+    ],
     "Plexus": [
         "Plexus Classworlds License",
+        false,
+        false
+    ],
+    "pnmstitch": [
+        "pnmstitch License",
         false,
         false
     ],
@@ -2039,6 +2489,16 @@
         true,
         false
     ],
+    "Python-2.0.1": [
+        "Python License 2.0.1",
+        false,
+        false
+    ],
+    "python-ldap": [
+        "Python ldap License",
+        false,
+        false
+    ],
     "Qhull": [
         "Qhull License",
         false,
@@ -2047,6 +2507,11 @@
     "QPL-1.0": [
         "Q Public License 1.0",
         true,
+        false
+    ],
+    "QPL-1.0-INRIA-2004": [
+        "Q Public License 1.0 - INRIA 2004 variant",
+        false,
         false
     ],
     "Rdisc": [
@@ -2134,6 +2599,16 @@
         false,
         false
     ],
+    "SGI-OpenGL": [
+        "SGI OpenGL License",
+        false,
+        false
+    ],
+    "SGP4": [
+        "SGP4 Permission Notice",
+        false,
+        false
+    ],
     "SHL-0.5": [
         "Solderpad Hardware License v0.5",
         false,
@@ -2159,6 +2634,11 @@
         false,
         false
     ],
+    "SL": [
+        "SL License",
+        false,
+        false
+    ],
     "Sleepycat": [
         "Sleepycat License",
         true,
@@ -2176,6 +2656,16 @@
     ],
     "SNIA": [
         "SNIA Public License 1.1",
+        false,
+        false
+    ],
+    "snprintf": [
+        "snprintf License",
+        false,
+        false
+    ],
+    "Soundex": [
+        "Soundex License",
         false,
         false
     ],
@@ -2197,6 +2687,11 @@
     "SPL-1.0": [
         "Sun Public License v1.0",
         true,
+        false
+    ],
+    "ssh-keyscan": [
+        "ssh-keyscan License",
+        false,
         false
     ],
     "SSH-OpenSSH": [
@@ -2224,8 +2719,23 @@
         false,
         false
     ],
+    "SunPro": [
+        "SunPro License",
+        false,
+        false
+    ],
     "SWL": [
         "Scheme Widget Library (SWL) Software License Agreement",
+        false,
+        false
+    ],
+    "swrule": [
+        "swrule License",
+        false,
+        false
+    ],
+    "Symlinks": [
+        "Symlinks License",
         false,
         false
     ],
@@ -2244,6 +2754,11 @@
         false,
         false
     ],
+    "TermReadKey": [
+        "TermReadKey License",
+        false,
+        false
+    ],
     "TMate": [
         "TMate Open Source License",
         false,
@@ -2259,6 +2774,26 @@
         false,
         false
     ],
+    "TPDL": [
+        "Time::ParseDate License",
+        false,
+        false
+    ],
+    "TPL-1.0": [
+        "THOR Public License 1.0",
+        false,
+        false
+    ],
+    "TTWL": [
+        "Text-Tabs+Wrap License",
+        false,
+        false
+    ],
+    "TTYP0": [
+        "TTYP0 License",
+        false,
+        false
+    ],
     "TU-Berlin-1.0": [
         "Technische Universitaet Berlin License 1.0",
         false,
@@ -2269,9 +2804,19 @@
         false,
         false
     ],
+    "UCAR": [
+        "UCAR License",
+        false,
+        false
+    ],
     "UCL-1.0": [
         "Upstream Compatibility License v1.0",
         true,
+        false
+    ],
+    "ulem": [
+        "ulem License",
+        false,
         false
     ],
     "Unicode-DFS-2015": [
@@ -2289,6 +2834,11 @@
         false,
         false
     ],
+    "UnixCrypt": [
+        "UnixCrypt License",
+        false,
+        false
+    ],
     "Unlicense": [
         "The Unlicense",
         true,
@@ -2297,6 +2847,11 @@
     "UPL-1.0": [
         "Universal Permissive License v1.0",
         true,
+        false
+    ],
+    "URT-RLE": [
+        "Utah Raster Toolkit Run Length Encoded License",
+        false,
         false
     ],
     "Vim": [
@@ -2329,9 +2884,19 @@
         false,
         false
     ],
+    "w3m": [
+        "w3m License",
+        false,
+        false
+    ],
     "Watcom-1.0": [
         "Sybase Open Watcom Public License 1.0",
         true,
+        false
+    ],
+    "Widget-Workshop": [
+        "Widget Workshop License",
+        false,
         false
     ],
     "Wsuipa": [
@@ -2359,8 +2924,18 @@
         false,
         false
     ],
+    "Xdebug-1.03": [
+        "Xdebug License v 1.03",
+        false,
+        false
+    ],
     "Xerox": [
         "Xerox License",
+        false,
+        false
+    ],
+    "Xfig": [
+        "Xfig License",
         false,
         false
     ],
@@ -2371,6 +2946,11 @@
     ],
     "xinetd": [
         "xinetd License",
+        false,
+        false
+    ],
+    "xlock": [
+        "xlock License",
         false,
         false
     ],
@@ -2401,6 +2981,11 @@
     ],
     "Zed": [
         "Zed License",
+        false,
+        false
+    ],
+    "Zeeff": [
+        "Zeeff License",
         false,
         false
     ],

--- a/src/SpdxLicensesUpdater.php
+++ b/src/SpdxLicensesUpdater.php
@@ -24,7 +24,7 @@ class SpdxLicensesUpdater
      * @param string $url
      * @return void
      */
-    public function dumpLicenses($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')
+    public function dumpLicenses($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json')
     {
         if (null === $file) {
             $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::LICENSES_FILE;
@@ -49,7 +49,7 @@ class SpdxLicensesUpdater
      * @param string $url
      * @return void
      */
-    public function dumpExceptions($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions.json')
+    public function dumpExceptions($file = null, $url = 'https://raw.githubusercontent.com/spdx/license-list-data/main/json/exceptions.json')
     {
         if (null === $file) {
             $file = SpdxLicenses::getResourcesDir() . '/' . SpdxLicenses::EXCEPTIONS_FILE;


### PR DESCRIPTION
Update SPDX license list to latest version 3.22

Update the branch name from `master` to `main` for `spdx/license-list-data` repo (done in v3.19).

See:
- https://github.com/spdx/license-list-XML/releases/tag/v3.22
- https://github.com/spdx/license-list-XML/releases/tag/v3.21
- https://github.com/spdx/license-list-XML/releases/tag/v3.20
- https://github.com/spdx/license-list-XML/releases/tag/v3.19
- https://github.com/spdx/license-list-XML/releases/tag/v3.18
- https://github.com/spdx/license-list-XML/releases/tag/v3.17
- https://github.com/spdx/license-list-XML/releases/tag/v3.16

for a summary of changes.